### PR TITLE
ci: fix multi-arch smoke test on the classic image store

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -98,12 +98,19 @@ jobs:
       # flaky, do NOT downgrade this to continue-on-error -- a smoke test that cannot fail
       # is the bug it exists to prevent. Upgrade path: build on a native `ubuntu-24.04-arm`
       # runner (free for public repos) via a matrix, and drop QEMU entirely.
+      #
+      # The `docker image rm` is load-bearing: with the classic overlay2 image store a
+      # digest can hold exactly one platform variant, so pulling the arm64 variant of a
+      # digest already present as amd64 fails with `cannot overwrite digest`. Docker
+      # Desktop's containerd store holds both and hides this, so it does not reproduce
+      # locally. Drop the image between platforms.
       - name: Smoke test image on every published platform
         env:
           IMAGE: ${{ steps.image.outputs.ref }}
         run: |
           for platform in linux/amd64 linux/arm64; do
             echo "::group::smoke $platform"
+            docker image rm -f "$IMAGE" >/dev/null 2>&1 || true
             docker run -d --name smoke --platform "$platform" -p 3000:3000 "$IMAGE"
             echo "arch inside container: $(docker exec smoke uname -m)"
             for _ in $(seq 60); do


### PR DESCRIPTION
## What & why

CD #18 failed in `build-push`, at the smoke test:

    docker: cannot overwrite digest sha256:da96e3ed...

The amd64 iteration leaves the image in the local store under its index digest.
The arm64 iteration pulls the same digest for a different platform, and with the
classic overlay2 image store a digest holds exactly one platform variant, so the
daemon refuses.

arm64 itself is fine. It pulled and would have booted; the failure is in the loop,
not in the image.

This did not reproduce locally because Docker Desktop defaults to the containerd
image store, which holds both variants under one digest and hides the conflict.
The smoke test was verified on a platform that was not the target platform.

## Changes

- Drop the image between platforms in the smoke loop.

## Verified

`docker image rm -f` accepts a digest reference; the subsequent pull fetches the
correct variant and reports `aarch64`.

## Note

CD #18 died before `attest` and `cosign sign`, so `ghcr.io/…:latest` and
`sha-6c88b55` currently point at an unsigned image. That is the designed
behaviour — the deploy gate refuses unsigned digests — but do not pull `latest`
and trust it until the next CD run overwrites it.
